### PR TITLE
Improve Error Message for RedScale's Wrapper in regards to clang++ binary

### DIFF
--- a/redscale_wrappers/CMakeLists.txt
+++ b/redscale_wrappers/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if (NOT TARGET redscale)
     # Check that we got the RedSCALE compiler.
     if (NOT "${CMAKE_CXX_COMPILER}" MATCHES "/targets/gfx[^/]+/bin/clang\\+\\+")
-        fatal_error("CMAKE_CXX_COMPILER does not point to RedSCALE's Clang. Did you forget to set CMAKE_CXX_COMPILER?")
+		fatal_error("CMAKE_CXX_COMPILER does not point to RedSCALE's Clang. Did you forget to set CMAKE_CXX_COMPILER? Ensure it points to the clang++ binary.")
     endif()
 
     # Add the corresponding RedSCALE directory to the CMake prefix path.


### PR DESCRIPTION
I'm trying to get redscale wrappers working so I can compile a CUDA project for my AMD GPU.
I was a little confused about the documentation here.
The error message did not specify to use the clang++ binary which is perhaps pretty obvious. But I was confused for a few minutes. Just updating it to ensure the user knows they need to use redstone's clang++ binary.